### PR TITLE
AB#38110 add send notif to user team sample query

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -1440,7 +1440,7 @@
             }
         ],
         "postBody": "{\r\n    \"topic\": {\r\n    \"source\": \"entityUrl\",\r\n    \"value\": \"https://graph.microsoft.com/v1.0/teams/b126aba2-a1fb-4e03-acc3-410b5d5af2dc\"\r\n    },\r\n    \"activityType\": \"pendingFinanceApprovalRequests\",\r\n    \"previewText\": {\r\n    \"content\": \"Internal spending team has a pending finance approval requests\"\r\n    },\r\n    \"recipient\": {\r\n    \"@odata.type\": \"microsoft.graph.aadUserNotificationRecipient\",\r\n    \"userId\": \"c8c95113-2dea-457d-9da4-e963d3f7a98b\"\r\n    },\r\n    \"templateParameters\": [\r\n    {\r\n    \"name\": \"pendingRequestCount\",\r\n    \"value\": \"5\"\r\n    }\r\n    ]\r\n    }",
-        "tip": "This query requires a teams id. To find the team id, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams",
+        "tip": "This query requires a teams id. To find the team id, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams. If the notification is being sent by an application via application permissions, the recipient of the notification must also have the application installed.",
         "skipTest": false
     },
     {

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -1439,7 +1439,7 @@
                 "value": "application/json"
             }
         ],
-        "postBody": "{\r\n    \"topic\": {\r\n    \"source\": \"entityUrl\",\r\n    \"value\": \"https://graph.microsoft.com/v1.0/teams/{teams-id}\"\r\n    },\r\n    \"activityType\": \"pendingFinanceApprovalRequests\",\r\n    \"previewText\": {\r\n    \"content\": \"Internal spending team has a pending finance approval requests\"\r\n    },\r\n    \"recipient\": {\r\n    \"@odata.type\": \"microsoft.graph.aadUserNotificationRecipient\",\r\n    \"userId\": \"{recipient-user-id}\"\r\n    },\r\n    \"templateParameters\": [\r\n    {\r\n    \"name\": \"pendingRequestCount\",\r\n    \"value\": \"5\"\r\n    }\r\n    ]\r\n    }",
+        "postBody": "{\r\n    \"topic\": {\r\n    \"source\": \"entityUrl\",\r\n    \"value\": \"https://graph.microsoft.com/v1.0/teams/{teams-id}\"\r\n    },\r\n    \"activityType\": \"pendingFinanceApprovalRequests\",\r\n    \"previewText\": {\r\n    \"content\": \"Test activity feed notification from Graph Explorer\"\r\n    },\r\n    \"recipient\": {\r\n    \"@odata.type\": \"microsoft.graph.aadUserNotificationRecipient\",\r\n    \"userId\": \"{recipient-user-id}\"\r\n    },\r\n    \"templateParameters\": [\r\n    {\r\n    \"name\": \"pendingRequestCount\",\r\n    \"value\": \"5\"\r\n    }\r\n    ]\r\n    }",
         "tip": "This query requires a teams id and a recipient's user id. To find the team id, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams . To find a user's id, you can run: 1) GET https://graph.microsoft.com/v1.0/me/ or 2) GET https://graph.microsoft.com/v1.0/users . The recipient of the notification must also have the application installed.",
         "skipTest": false
     },

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -1430,7 +1430,7 @@
         "id": "8cd7a323-478e-4828-878f-7e6962728a9b",
         "category": "Microsoft Teams",
         "method": "POST",
-        "humanName": "send activity notification",
+        "humanName": "send activity notification in the scope of a team",
         "requestUrl": "/v1.0/teams/{id}/sendActivityNotification",
         "docLink": "https://docs.microsoft.com/en-us/graph/api/team-sendactivitynotification?view=graph-rest-1.0&tabs=http",
         "headers": [
@@ -1439,8 +1439,8 @@
                 "value": "application/json"
             }
         ],
-        "postBody": "{\r\n    \"topic\": {\r\n    \"source\": \"entityUrl\",\r\n    \"value\": \"https://graph.microsoft.com/v1.0/teams/b126aba2-a1fb-4e03-acc3-410b5d5af2dc\"\r\n    },\r\n    \"activityType\": \"pendingFinanceApprovalRequests\",\r\n    \"previewText\": {\r\n    \"content\": \"Internal spending team has a pending finance approval requests\"\r\n    },\r\n    \"recipient\": {\r\n    \"@odata.type\": \"microsoft.graph.aadUserNotificationRecipient\",\r\n    \"userId\": \"c8c95113-2dea-457d-9da4-e963d3f7a98b\"\r\n    },\r\n    \"templateParameters\": [\r\n    {\r\n    \"name\": \"pendingRequestCount\",\r\n    \"value\": \"5\"\r\n    }\r\n    ]\r\n    }",
-        "tip": "This query requires a teams id. To find the team id, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams. If the notification is being sent by an application via application permissions, the recipient of the notification must also have the application installed.",
+        "postBody": "{\r\n    \"topic\": {\r\n    \"source\": \"entityUrl\",\r\n    \"value\": \"https://graph.microsoft.com/v1.0/teams/{teams-id}\"\r\n    },\r\n    \"activityType\": \"pendingFinanceApprovalRequests\",\r\n    \"previewText\": {\r\n    \"content\": \"Internal spending team has a pending finance approval requests\"\r\n    },\r\n    \"recipient\": {\r\n    \"@odata.type\": \"microsoft.graph.aadUserNotificationRecipient\",\r\n    \"userId\": \"{recipient-user-id}\"\r\n    },\r\n    \"templateParameters\": [\r\n    {\r\n    \"name\": \"pendingRequestCount\",\r\n    \"value\": \"5\"\r\n    }\r\n    ]\r\n    }",
+        "tip": "This query requires a teams id and a recipient's user id. To find the team id, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams . To find a user's id, you can run: 1) GET https://graph.microsoft.com/v1.0/me/ or 2) GET https://graph.microsoft.com/v1.0/users . The recipient of the notification must also have the application installed.",
         "skipTest": false
     },
     {

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -1439,7 +1439,7 @@
                 "value": "application/json"
             }
         ],
-        "postBody": "{\r\n    \"topic\": {\r\n    \"source\": \"entityUrl\",\r\n    \"value\": \"https://graph.microsoft.com/v1.0/teams/b126aba2-a1fb-4e03-acc3-410b5d5af2dc\"\r\n    },\r\n    \"activityType\": \"pendingFinanceApprovalRequests\",\r\n    \"previewText\": {\r\n    \"content\": \"Internal spending team has a pending finance approval requests\"\r\n    },\r\n    \"recipient\": {\r\n    \"@odata.type\": \"microsoft.graph.aadUserNotificationRecipient\",\r\n    \"userId\": \"d4c3656e-7215-4624-bfe3-5f08b2592b8d\"\r\n    },\r\n    \"templateParameters\": [\r\n    {\r\n    \"name\": \"pendingRequestCount\",\r\n    \"value\": \"5\"\r\n    }\r\n    ]\r\n    }",
+        "postBody": "{\r\n    \"topic\": {\r\n    \"source\": \"entityUrl\",\r\n    \"value\": \"https://graph.microsoft.com/v1.0/teams/b126aba2-a1fb-4e03-acc3-410b5d5af2dc\"\r\n    },\r\n    \"activityType\": \"pendingFinanceApprovalRequests\",\r\n    \"previewText\": {\r\n    \"content\": \"Internal spending team has a pending finance approval requests\"\r\n    },\r\n    \"recipient\": {\r\n    \"@odata.type\": \"microsoft.graph.aadUserNotificationRecipient\",\r\n    \"userId\": \"c8c95113-2dea-457d-9da4-e963d3f7a98b\"\r\n    },\r\n    \"templateParameters\": [\r\n    {\r\n    \"name\": \"pendingRequestCount\",\r\n    \"value\": \"5\"\r\n    }\r\n    ]\r\n    }",
         "tip": "This query requires a teams id. To find the team id, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams",
         "skipTest": false
     },

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -1427,6 +1427,23 @@
         "skipTest": false
     },
     {
+        "id": "8cd7a323-478e-4828-878f-7e6962728a9b",
+        "category": "Microsoft Teams",
+        "method": "POST",
+        "humanName": "send activity notification",
+        "requestUrl": "/v1.0/teams/{id}/sendActivityNotification",
+        "docLink": "https://docs.microsoft.com/en-us/graph/api/team-sendactivitynotification?view=graph-rest-1.0&tabs=http",
+        "headers": [
+            {
+                "name": "Content-Type",
+                "value": "application/json"
+            }
+        ],
+        "postBody": "{\r\n    \"topic\": {\r\n    \"source\": \"entityUrl\",\r\n    \"value\": \"https://graph.microsoft.com/v1.0/teams/b126aba2-a1fb-4e03-acc3-410b5d5af2dc\"\r\n    },\r\n    \"activityType\": \"pendingFinanceApprovalRequests\",\r\n    \"previewText\": {\r\n    \"content\": \"Internal spending team has a pending finance approval requests\"\r\n    },\r\n    \"recipient\": {\r\n    \"@odata.type\": \"microsoft.graph.aadUserNotificationRecipient\",\r\n    \"userId\": \"d4c3656e-7215-4624-bfe3-5f08b2592b8d\"\r\n    },\r\n    \"templateParameters\": [\r\n    {\r\n    \"name\": \"pendingRequestCount\",\r\n    \"value\": \"5\"\r\n    }\r\n    ]\r\n    }",
+        "tip": "This query requires a teams id. To find the team id, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams",
+        "skipTest": false
+    },
+    {
         "id": "d8a3cd75-6ddf-4215-89de-3c2dab6b9585",
         "category": "Microsoft Teams (beta)",
         "method": "GET",


### PR DESCRIPTION
This PR adds the [Send Activity Notification (in the scope of a team)](https://docs.microsoft.com/en-us/graph/api/team-sendactivitynotification?view=graph-rest-1.0&tabs=http) sample query to the sample queries JSON file. 