### PR TITLE
AB#39080 add app permissions sample query: GET teams channels

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -3025,7 +3025,7 @@
     },
     {
         "id": "fe15123a-507a-45d8-aa29-e5b25f5c0ac7",
-        "category": "Microsoft Teams",
+        "category": "Microsoft Teams (beta)",
         "method": "GET",
         "humanName": "list channel messages",
         "requestUrl": "/beta/teams/{team-id}/channels/{channel-id}/messages",

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -2983,6 +2983,15 @@
     }
   ],
   "TeamsAppSampleQueries": [
-      
+    {
+        "id": "44a072cc-c5c6-40f2-ab21-e7b0c417bb00",
+        "category": "Microsoft Teams",
+        "method": "GET",
+        "humanName": "channels of a team which I am member of",
+        "requestUrl": "/v1.0/teams/{team-id}/channels",
+        "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/channel_list",
+        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams",
+        "skipTest": false
+    }
   ]
 }

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -2985,11 +2985,11 @@
   "TeamsAppSampleQueries": [
     {
         "id": "44a072cc-c5c6-40f2-ab21-e7b0c417bb00",
-        "category": "Microsoft Teams",
+        "category": "Microsoft Teams (beta)",
         "method": "GET",
         "humanName": "channels of a team which I am member of",
-        "requestUrl": "/v1.0/teams/{team-id}/channels",
-        "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/channel_list",
+        "requestUrl": "/beta/teams/{team-id}/channels",
+        "docLink": "https://docs.microsoft.com/en-us/graph/api/channel-list?view=graph-rest-beta",
         "tip": "This query requires a team id.  To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams",
         "skipTest": false
     },

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -3015,11 +3015,11 @@
     },
     {
         "id": "da59a1e1-4979-485e-a128-44f28d6d67ac",
-        "category": "Microsoft Teams",
+        "category": "Microsoft Teams (beta)",
         "method": "GET",
         "humanName": "get list of members in team",
-        "requestUrl": "/v1.0/teams/{team-id}/members",
-        "docLink": "https://docs.microsoft.com/en-us/graph/api/team-list-members?view=graph-rest-1.0&tabs=http",
+        "requestUrl": "/beta/teams/{team-id}/members",
+        "docLink": "https://docs.microsoft.com/en-us/graph/api/team-list-members?view=graph-rest-beta",
         "tip": "This query requires a team id. To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams.",
         "skipTest": false
     },


### PR DESCRIPTION
Copied from the other GET teams channels sample query, but with new generated GUID and added information in the tip to ensure the user knows to switch to user mode in order to get Teams IDs. 