### PR TITLE
AB#39081 add app permissions sample query: POST teams channels

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -3032,7 +3032,7 @@
     },
     {
         "id": "fe15123a-507a-45d8-aa29-e5b25f5c0ac7",
-        "category": "Microsoft Teams",
+        "category": "Microsoft Teams (beta)",
         "method": "GET",
         "humanName": "list channel messages",
         "requestUrl": "/beta/teams/{team-id}/channels/{channel-id}/messages",

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -2985,11 +2985,11 @@
   "TeamsAppSampleQueries": [
     {
         "id": "9d9dc771-9926-4e41-b2e9-26159bb80c85",
-        "category": "Microsoft Teams",
+        "category": "Microsoft Teams (beta)",
         "method": "POST",
         "humanName": "create channel",
-        "requestUrl": "/v1.0/teams/{team-id}/channels",
-        "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/channel_post",
+        "requestUrl": "/beta/teams/{team-id}/channels",
+        "docLink": "https://docs.microsoft.com/en-us/graph/api/channel-post?view=graph-rest-beta",
         "headers": [
             {
                 "name": "Content-type",

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -2983,6 +2983,22 @@
     }
   ],
   "TeamsAppSampleQueries": [
-      
+    {
+        "id": "9d9dc771-9926-4e41-b2e9-26159bb80c85",
+        "category": "Microsoft Teams",
+        "method": "POST",
+        "humanName": "create channel",
+        "requestUrl": "/v1.0/teams/{team-id}/channels",
+        "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/channel_post",
+        "headers": [
+            {
+                "name": "Content-type",
+                "value": "application/json"
+            }
+        ],
+        "postBody": "{\r\n   \"displayName\": \"Architecture Discussion\",\r\n   \"description\": \"This channel is where we debate all future architecture plans\"\r\n }",
+        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams.",
+        "skipTest": false
+    }
   ]
 }

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -1418,7 +1418,7 @@
             }
         ],
         "postBody": "{\r\n   \"displayName\": \"Architecture Discussion\",\r\n   \"description\": \"This channel is where we debate all future architecture plans\"\r\n }",
-        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams.",
+        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams .",
         "skipTest": false
     },
     {
@@ -2997,7 +2997,7 @@
             }
         ],
         "postBody": "{\r\n   \"displayName\": \"Architecture Discussion\",\r\n   \"description\": \"This channel is where we debate all future architecture plans\"\r\n }",
-        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams.",
+        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams .",
         "skipTest": false
     }
   ]

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -1418,7 +1418,7 @@
             }
         ],
         "postBody": "{\r\n   \"displayName\": \"Architecture Discussion\",\r\n   \"description\": \"This channel is where we debate all future architecture plans\"\r\n }",
-        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams .",
+        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams.",
         "skipTest": false
     },
     {

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -2997,7 +2997,9 @@
             }
         ],
         "postBody": "{\r\n   \"displayName\": \"Architecture Discussion\",\r\n   \"description\": \"This channel is where we debate all future architecture plans\"\r\n }",
-        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams .",
+        "tip": "This query requires a team id.  To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams ."
+    },
+    {
         "id": "44a072cc-c5c6-40f2-ab21-e7b0c417bb00",
         "category": "Microsoft Teams (beta)",
         "method": "GET",


### PR DESCRIPTION
Copied from the other POST teams channels sample query, but with new generated GUID and added information in the tip to ensure the user knows to switch to user mode in order to get Teams IDs. 
Also added a space between the link and the period in the tip so that the period is not automatically added to the autofill input box when a user clicks on it. 