### PR TITLE
AB#39086 AB#39087 AB#39088 Added get team tabs, get team apps, and get team RSCs sample queries

### DIFF
--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -3015,7 +3015,7 @@
         },
         {
             "id": "fe15123a-507a-45d8-aa29-e5b25f5c0ac7",
-            "category": "Microsoft Teams",
+            "category": "Microsoft Teams (beta)",
             "method": "GET",
             "humanName": "list channel messages",
             "requestUrl": "/beta/teams/{team-id}/channels/{channel-id}/messages",

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -2983,7 +2983,7 @@
     }
   ],
   "TeamsAppSampleQueries": [
-    {
+        {
             "id": "3142bf45-6ab7-4008-a2a4-3c7555773cef",
             "category": "Microsoft Teams (beta)",
             "method": "GET",
@@ -3021,6 +3021,36 @@
             "requestUrl": "/beta/teams/{team-id}/channels/{channel-id}/messages",
             "docLink": "https://docs.microsoft.com/en-us/graph/api/channel-list-messages?view=graph-rest-beta&tabs=http",
             "tip": "This query requires a team id and a channel id. To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams. To find the channel id of channels you belong to, stay in user (delegated permissions) mode and run: GET https://graph.microsoft.com/beta/teams/{team-id}/channels.",
+            "skipTest": false
+        },
+        {
+            "id": "a748f894-bb43-4585-8a34-cc093d91c946",
+            "category": "Microsoft Teams",
+            "method": "GET",
+            "humanName": "tabs in a channel",
+            "requestUrl": "/beta/teams/{team-id}/channels/{channel-id}/tabs?$expand=teamsApp",
+            "docLink": "https://docs.microsoft.com/en-us/graph/api/channel-list-tabs?view=graph-rest-beta&tabs=http",
+            "tip": "This query requires a team id and a channel id. To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams. To find the channel id of channels you belong to, stay in user (delegated permissions) mode and run: GET https://graph.microsoft.com/beta/teams/{team-id}/channels.",
+            "skipTest": false
+        },
+        {
+            "id": "428bde00-a605-42cc-90b3-e2b50c359c70",
+            "category": "Microsoft Teams",
+            "method": "GET",
+            "humanName": "apps in a team",
+            "requestUrl": "/beta/teams/{team-id}/installedApps?$expand=teamsAppDefinition",
+            "docLink": "https://docs.microsoft.com/en-us/graph/api/team-list-installedapps?view=graph-rest-beta&tabs=http",
+            "tip": "This query requires a team id. To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams.",
+            "skipTest": false
+        },
+        {
+            "id": "4c676bb1-c267-4a96-ac05-91d3db93b8ee",
+            "category": "Microsoft Teams",
+            "method": "GET",
+            "humanName": "list resource-specific permission grants on a team",
+            "requestUrl": "/beta/teams/{team-id}/permissionGrants",
+            "docLink": "https://docs.microsoft.com/en-us/graph/api/team-list-permissiongrants?view=graph-rest-beta&tabs=http",
+            "tip": "This query requires a team id. To find the team id of teams you belong to, you can switch to user (delegated permissions) mode and run: GET https://graph.microsoft.com/v1.0/me/joinedTeams.",
             "skipTest": false
         }
   ]

--- a/sample-queries/sample-queries.json
+++ b/sample-queries/sample-queries.json
@@ -3025,7 +3025,7 @@
         },
         {
             "id": "a748f894-bb43-4585-8a34-cc093d91c946",
-            "category": "Microsoft Teams",
+            "category": "Microsoft Teams (beta)",
             "method": "GET",
             "humanName": "tabs in a channel",
             "requestUrl": "/beta/teams/{team-id}/channels/{channel-id}/tabs?$expand=teamsApp",
@@ -3035,7 +3035,7 @@
         },
         {
             "id": "428bde00-a605-42cc-90b3-e2b50c359c70",
-            "category": "Microsoft Teams",
+            "category": "Microsoft Teams (beta)",
             "method": "GET",
             "humanName": "apps in a team",
             "requestUrl": "/beta/teams/{team-id}/installedApps?$expand=teamsAppDefinition",
@@ -3045,7 +3045,7 @@
         },
         {
             "id": "4c676bb1-c267-4a96-ac05-91d3db93b8ee",
-            "category": "Microsoft Teams",
+            "category": "Microsoft Teams (beta)",
             "method": "GET",
             "humanName": "list resource-specific permission grants on a team",
             "requestUrl": "/beta/teams/{team-id}/permissionGrants",


### PR DESCRIPTION
ADO Board Links: [Task #39086](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/39086), [Task #39087](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/39087), and [Task #39088](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/39088)

Copied user mode Teams sample queries, but with new generated GUIDs and added information in the tip to ensure the user knows to switch to user mode in order to get Teams IDs and Channel IDs.